### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -756,7 +756,7 @@ function cleanText(text: string, opts: CleanOptions): string {
   const SENTINEL_ZWJ = ""; // private-use marker
   if (opts.preserveEmoji) {
     try {
-      const EP = "\p{Extended_Pictographic}";
+      const EP = "\\p{Extended_Pictographic}";
       const reZWJ = new RegExp(`(${EP})\u200D(${EP})`, "gu");
       t = t.replace(reZWJ, `$1${SENTINEL_ZWJ}$2`);
     } catch {


### PR DESCRIPTION
Potential fix for [https://github.com/sugarcypher/Ace-Paste-Cleaner/security/code-scanning/1](https://github.com/sugarcypher/Ace-Paste-Cleaner/security/code-scanning/1)

To fix this problem, we need to ensure that when constructing the `EP` string (used as a property escape in a regular expression), the backslash survives the string literal and appears in the final RegExp pattern string. In JavaScript/TypeScript, this means doubling the backslash. Change `const EP = "\p{Extended_Pictographic}";` to `const EP = "\\p{Extended_Pictographic}";` on line 759 of `src/App.tsx`. No imports or further code changes are necessary, as this is a string literal adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
